### PR TITLE
fixes: Post class, type casting

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -15,14 +15,14 @@ Types::QueryType = GraphQL::ObjectType.define do
     type Types::UserType
     argument :id, !types.ID
     description "Find a User by ID"
-    resolve ->(obj, args, ctx) { Loaders::Record.for(User).load(args["id"]) }
+    resolve ->(obj, args, ctx) { Loaders::Record.for(User).load(args["id"].to_i) }
   end
 
   field :post do
     type Types::PostType
     argument :id, !types.ID
     description "Find a Post by ID"
-    resolve ->(obj, args, ctx) { Loaders::Record.for(Product).load(args["id"]) }
+    resolve ->(obj, args, ctx) { Loaders::Record.for(Post).load(args["id"].to_i) }
   end
 
   field :posts do


### PR DESCRIPTION
2 small fixes as I was playing with this toy app:

1. `Post` class rather than `Product`
2. More tricky: I found out that args["id"] was always cast as a String with queries from graphiql. if `graphiql-rails` is using Relay it makes sense (base on [this](https://github.com/rmosolgo/graphql-ruby/issues/507)).

However, User and Post Ids are integers. Doing a query like would raise a KeyError ([explanation](https://github.com/Shopify/graphql-batch/pull/15)):
```
{
  post(id: 1) {
    id
  }
}
```
The `#to_i` solution is ugly but maybe it's enough for a toy app 🙂 
